### PR TITLE
Support anonymous config value

### DIFF
--- a/handler.lua
+++ b/handler.lua
@@ -41,6 +41,12 @@ function JwtClaimsValidateHandler:access(conf)
   JwtClaimsValidateHandler.super.access(self)
   local continue_on_error = conf.continue_on_error
 
+  if ngx.ctx.authenticated_consumer and conf.anonymous ~= "" then
+    -- we're already authenticated, and we're configured for using anonymous,
+    -- hence we're in a logical OR between auth methods and we're already done.
+    return
+  end
+
   local token, err = retrieve_token(ngx.req, conf)
   if err and not continue_on_error then
     return responses.send_HTTP_INTERNAL_SERVER_ERROR(err)

--- a/schema.lua
+++ b/schema.lua
@@ -1,8 +1,9 @@
 local cjson = require "cjson"
+local utils = require "kong.tools.utils"
 
 local function claim_check(value, conf)
   local valid_types = {
-    ["string"]  = true, 
+    ["string"]  = true,
     ["boolean"] = true,
     ["number"]  = true
   }
@@ -17,10 +18,19 @@ local function claim_check(value, conf)
   end
 end
 
+local function check_user(anonymous)
+  if anonymous == "" or utils.is_valid_uuid(anonymous) then
+    return true
+  end
+
+  return false, "the anonymous user must be empty or a valid uuid"
+end
+
 return {
   no_consumer = true,
   fields = {
-    uri_param_names = {type = "array", default = {"jwt"}},
-    claims = { type = "table", func = claim_check }
+    uri_param_names = { type = "array", default = { "jwt" } },
+    claims = { type = "table", func = claim_check },
+    anonymous = { type = "string", default = "", func = check_user }
   }
 }

--- a/schema.lua
+++ b/schema.lua
@@ -30,7 +30,7 @@ return {
   no_consumer = true,
   fields = {
     uri_param_names = { type = "array", default = { "jwt" } },
-    claims = { type = "table", func = claim_check },
+    claims = { type = "table", default = { }, func = claim_check },
     anonymous = { type = "string", default = "", func = check_user }
   }
 }


### PR DESCRIPTION
This change helps `jwt-claims-validate` play nice when the `jwt` plugin's `config.anonymous` option is used as [described here](https://getkong.org/plugins/jwt/).